### PR TITLE
refactor: replaced `bytes.NewBuffer` with `bytes.NewBufferString`

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -52,7 +52,7 @@ var towerCmd = &cobra.Command{
 		}
 
 		viper.SetConfigType("yaml")
-		err = viper.ReadConfig(bytes.NewBuffer([]byte(configParsed)))
+		err = viper.ReadConfig(bytes.NewBufferString(configParsed))
 
 		if err != nil {
 			panic(fmt.Sprintf(

--- a/core/service/http.go
+++ b/core/service/http.go
@@ -66,7 +66,7 @@ func (h *HTTPClient) Post(ctx context.Context, endpoint string, data string, par
 		return nil, err
 	}
 
-	req, _ := http.NewRequest("POST", endpoint, bytes.NewBuffer([]byte(data)))
+	req, _ := http.NewRequest("POST", endpoint, bytes.NewBufferString(data))
 
 	req = req.WithContext(ctx)
 
@@ -96,7 +96,7 @@ func (h *HTTPClient) Put(ctx context.Context, endpoint string, data string, para
 		return nil, err
 	}
 
-	req, _ := http.NewRequest("PUT", endpoint, bytes.NewBuffer([]byte(data)))
+	req, _ := http.NewRequest("PUT", endpoint, bytes.NewBufferString(data))
 
 	req = req.WithContext(ctx)
 
@@ -126,7 +126,7 @@ func (h *HTTPClient) Patch(ctx context.Context, endpoint string, data string, pa
 		return nil, err
 	}
 
-	req, _ := http.NewRequest("PATCH", endpoint, bytes.NewBuffer([]byte(data)))
+	req, _ := http.NewRequest("PATCH", endpoint, bytes.NewBufferString(data))
 
 	req = req.WithContext(ctx)
 

--- a/pkg/loader.go
+++ b/pkg/loader.go
@@ -49,7 +49,7 @@ func LoadConfigs(path string) error {
 
 	viper.SetConfigType("yaml")
 
-	viper.ReadConfig(bytes.NewBuffer([]byte(data1)))
+	viper.ReadConfig(bytes.NewBufferString(data1))
 
 	viper.SetDefault("app.name", "x-x-x-x")
 


### PR DESCRIPTION
This PR change one function of bytes package with a similar one, as result code
produce less allocations on heap.